### PR TITLE
XSD Model utils docs and specs

### DIFF
--- a/lib/exsom/sax.ex
+++ b/lib/exsom/sax.ex
@@ -4,7 +4,6 @@ defmodule Exsom.SAX do
 
   @doc ~S"""
   """
-
   @spec parse(xml :: Exsom.chardata_xml, any, fun, any) :: any
   def parse(xml, acc, event_fun, opts), do: :erlsom.parse_sax(xml, acc, event_fun, opts)
 end

--- a/lib/exsom/xsd/model.ex
+++ b/lib/exsom/xsd/model.ex
@@ -1,7 +1,20 @@
 defmodule Exsom.XSD.Model do
-  # For the cases where a manual schema needs to be supplied
-  # (ex. cannot parse)
-  def from_map(model), do: :erlsom.add_xsd_model(model)
+  @moduledoc ~S"""
+  Model utilities.
 
+  For the cases where a manual schema needs to be supplied
+  (ex. cannot parse).
+  """
+
+  @doc ~S"""
+  Adds a simplified version of the W3C XMLSchema to an existing model.
+  """
+  @spec add_xml_schema(model :: Exsom.model) :: Exsom.model
+  def add_xml_schema(model), do: :erlsom.add_xsd_model(model)
+
+  @doc ~S"""
+  Merges two models.
+  """
+  @spec merge(model_1 :: Exsom.model, model_2 :: Exsom.model) :: Exsom.model
   def merge(model_1, model_2), do: :erlsom.add_model(model_1, model_2)
 end

--- a/test/exsom_test.exs
+++ b/test/exsom_test.exs
@@ -39,4 +39,14 @@ defmodule ExsomTest do
     charlist_xml = Exsom.Unicode.convert(@test_xml)
     assert charlist_xml == to_charlist(@test_xml)
   end
+
+  test "xsd / model utilities" do
+    { :ok, model } = Exsom.XSD.File.compile("test/examples/complex.xsd")
+
+    a = Exsom.XSD.Model.add_xml_schema(model)
+    b = Exsom.XSD.Model.merge(model, :erlsom_parseXsd.xsdModel())
+
+    assert a == b
+  end
+
 end


### PR DESCRIPTION
So, I was looking at `:erlsom.add_xsd_model(model)` and the related code in the erlsom library, and I couldn't for the life of me figure out what it is actually doing 😓 It appears to me that it adds the standard XMLSchema from W3C as defined in the schema itself (ie. `http://www.w3.org/2001/XMLSchema`). But, on the other hand, that doesn't seem very likely, does it? @expede , you named it `from_map`, can you tell me why?

EDIT:
I just noticed, this comes back again in the `:erlsom_type2xsd.make_xsd` function, that is `Model = erlsom_parseXsd:xsdModel()`.